### PR TITLE
Fix instances being affected by DeepPartial

### DIFF
--- a/src/Store.d.ts
+++ b/src/Store.d.ts
@@ -1,6 +1,6 @@
 import Rodux from "./index";
 
-type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
+type DeepPartial<T> = T extends Instance ? T : { [K in keyof T]?: DeepPartial<T[K]> };
 
 interface Store<S, A extends Rodux.Action = Rodux.AnyAction>
 	extends Rodux.Dispatcher<A> {


### PR DESCRIPTION
Current behaviour (minimal reproduction):
```typescript
const INITIAL_VALUE = {
    Players: [] as Player[]
}

interface ActionReceived extends Rodux.AnyAction {}

const reducer = Rodux.createReducer<typeof INITIAL_VALUE, ActionReceived>(INITIAL_VALUE, {
    someAction: (state) => { 
        return state
    }
})

// It would error here, thinks that the players are actual objects, and tries getting every property
const store = new Rodux.Store(reducer, INITIAL_VALUE) 
```
Playground Link: [Here](https://roblox-ts.com/playground/#code/JYWwDg9gTgLgBAJQgEwK4A84DMoRHAIgAEoAjdGAZwHpc10CBuAKGYGMIA7S+ASQDleAFV4BBADIB9AGoSAqgFE4AXjgBvZnC1wACgBsAhgE8AplEoAuOAG0AunAOVdh01DvMAvq2CcYZrAZsJnCibDDAXAgmQcAAbibIcCYUJpzITkj0AHSinEah4VzqXuxcPHBQCahBUCqIKBhZbJUGflFoNQA8MEZgJhBYcALCYlKy4ooANCFhEZxRMfHIAHwAFMMiEjLyCtMa2nCUeCYFc1arPK0mAJQqy+pwmgfalTCoUJyHMFdPWl4e11YHG48B40GCqk4JgA7vVsgBlGDg1aVDpmaYbUbbCYKa5AA)